### PR TITLE
Test the benchmark run on pull request

### DIFF
--- a/.github/workflows/continous-benchmark.yml
+++ b/.github/workflows/continous-benchmark.yml
@@ -23,7 +23,7 @@ jobs:
             6.0.x
       # Run benchmark with `go test -bench` and stores the output to a file
       - name: Run benchmark
-        run:  dotnet run --project ./GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj --framework net6 --runtimes net60 -c Release -- --job short -f *SerializeAndDeserialize*
+        run:  dotnet run --project ./GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj --framework net6 --runtimes net60 -c Release -- --job medium -f *SerializeAndDeserialize*
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
         uses: actions/cache@v1
@@ -31,13 +31,13 @@ jobs:
           path: ./cache
           key: ${{ runner.os }}-benchmark
       # Run `github-action-benchmark` action
-      - name: Store benchmark result for serialize feature collection
+      - name: Store benchmark result
         uses: Happypig375/github-action-benchmark@v1
         with:
           # What benchmark tool the output.txt came from
           tool: 'benchmarkdotnet'
           # Where the output from the benchmark tool is stored
-          output-file-path: 'src/BenchmarkDotNet.Artifacts/results/GeoJSON.Text.Test.Benchmark.SerializeAndDeserialize-report-full-compressed.json'
+          output-file-path: 'src/BenchmarkDotNet.Artifacts/results/GeoJSON.Text.Test.Benchmark.SerializeAndDeserialize-report-full.json'
           # Where the previous data file is stored
           external-data-json-path: ./cache/benchmark-data.json
           # Will comment on pull request when an alert happens

--- a/src/Directory.Builddss.props
+++ b/src/Directory.Builddss.props
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)key.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-</Project>

--- a/src/GeoJSON.Text.Test.Benchmark/TestConfig.cs
+++ b/src/GeoJSON.Text.Test.Benchmark/TestConfig.cs
@@ -20,18 +20,7 @@ namespace GeoJSON.Text.Test.Benchmark
     {
         public TestConfig()
         {
-            AddJob(Job.Default.WithRuntime(CoreRuntime.Core31)
-                .WithLaunchCount(1)     // benchmark process will be launched only once
-                .WithWarmupCount(3)     // 3 warmup iteration
-                .WithIterationCount(3),     // 3 target iteration,
-             Job.Default.WithRuntime(CoreRuntime.Core50)
-                .WithLaunchCount(1)     // benchmark process will be launched only once
-                .WithWarmupCount(3)     // 3 warmup iteration
-                .WithIterationCount(3),     // 3 target iteration,
-            Job.Default.WithRuntime(CoreRuntime.Core60)
-                .WithLaunchCount(1)     // benchmark process will be launched only once
-                .WithWarmupCount(3)     // 3 warmup iteration
-                .WithIterationCount(3));     // 3 target iteration);
+            WithOrderer(new FastestToSlowestOrderer());
 
             AddColumn(RankColumn.Roman);
             AddExporter(CsvMeasurementsExporter.Default,
@@ -40,6 +29,7 @@ namespace GeoJSON.Text.Test.Benchmark
                 JsonExporter.FullCompressed);
             AddDiagnoser(MemoryDiagnoser.Default);
         }
+
 
         private class FastestToSlowestOrderer : IOrderer
         {


### PR DESCRIPTION
Set the benchmark to only run on pull requests, and removed the directory build props file, since it causes the benchmarking to fail.

Furthermore, signing the builds can be done directly from the CLI.