### PR TITLE
Feature/only net standard20

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,7 +19,7 @@ jobs:
   build:
 
     name: 'Build and Test'
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     env: 
       VSTEST_CONNECTION_TIMEOUT: 900

--- a/.github/workflows/continous-benchmark.yml
+++ b/.github/workflows/continous-benchmark.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   benchmark:
     name: Continuous benchmarking
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     defaults:
       run:

--- a/.github/workflows/continous-benchmark.yml
+++ b/.github/workflows/continous-benchmark.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   benchmark:
     name: Continuous benchmarking
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     defaults:
       run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     name: 'Deploy to Nuget'
     if: github.event_name == 'release'
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     name: 'Deploy to Nuget'
     if: github.event_name == 'release'
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v2

--- a/src/GeoJSON.Text.Test.Benchmark/SerializeAndDeserialize.cs
+++ b/src/GeoJSON.Text.Test.Benchmark/SerializeAndDeserialize.cs
@@ -11,10 +11,10 @@ namespace GeoJSON.Text.Test.Benchmark
         string fileContents = "";
 
         // GeoJson.NET
-        private Net.Feature.FeatureCollection featureCollectionGeoJsonNET = new Net.Feature.FeatureCollection();
+        private readonly Net.Feature.FeatureCollection featureCollectionGeoJsonNET = new Net.Feature.FeatureCollection();
 
         // GeoJson.Text
-        private Text.Feature.FeatureCollection featureCollectionGeoJsonTEXT = new Text.Feature.FeatureCollection();
+        private readonly Text.Feature.FeatureCollection featureCollectionGeoJsonTEXT = new Text.Feature.FeatureCollection();
 
         [Params(1000, 10000)]
         public int N;

--- a/src/GeoJSON.Text.Test.Unit/Feature/FeatureTests.cs
+++ b/src/GeoJSON.Text.Test.Unit/Feature/FeatureTests.cs
@@ -462,7 +462,7 @@ namespace GeoJSON.Text.Tests.Feature
         }
 
 
-        private IGeometryObject GetGeometry()
+        private static IGeometryObject GetGeometry()
         {
             var coordinates = new List<LineString>
             {

--- a/src/GeoJSON.Text/Converters/PositionEnumerableConverter.cs
+++ b/src/GeoJSON.Text/Converters/PositionEnumerableConverter.cs
@@ -14,7 +14,7 @@ namespace GeoJSON.Text.Converters
     /// </summary>
     public class PositionEnumerableConverter : JsonConverter<IReadOnlyCollection<IPosition>>
     {
-        private static readonly PositionConverter PositionConverter = new PositionConverter();
+        private static readonly PositionConverter PositionConverter = new();
 
         /// <summary>
         ///     Determines whether this instance can convert the specified object type.

--- a/src/GeoJSON.Text/Feature/Feature.cs
+++ b/src/GeoJSON.Text/Feature/Feature.cs
@@ -143,7 +143,7 @@ namespace GeoJSON.Text.Feature
         /// <returns></returns>
         public bool Equals(Feature<TGeometry, TProps> other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
             return base.Equals(other)
                    && string.Equals(Id, other.Id)
@@ -153,7 +153,7 @@ namespace GeoJSON.Text.Feature
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
             return Equals((Feature<TGeometry, TProps>) obj);
@@ -306,7 +306,7 @@ namespace GeoJSON.Text.Feature
 
         public static bool operator ==(Feature<TGeometry> left, Feature<TGeometry> right)
         {
-            return left?.Equals(right) ?? ReferenceEquals(null, right);
+            return left?.Equals(right) ?? right is null;
         }
 
         public static bool operator !=(Feature<TGeometry> left, Feature<TGeometry> right)

--- a/src/GeoJSON.Text/Feature/Feature.cs
+++ b/src/GeoJSON.Text/Feature/Feature.cs
@@ -271,7 +271,7 @@ namespace GeoJSON.Text.Feature
 
         public bool Equals(Feature<TGeometry> other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             if (Geometry == null && other.Geometry == null)
@@ -294,7 +294,7 @@ namespace GeoJSON.Text.Feature
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals((Feature<TGeometry>) obj);
         }
@@ -311,7 +311,7 @@ namespace GeoJSON.Text.Feature
 
         public static bool operator !=(Feature<TGeometry> left, Feature<TGeometry> right)
         {
-            return !(left?.Equals(right) ?? ReferenceEquals(null, right));
+            return !(left?.Equals(right) ?? right is null);
         }
     }
 }

--- a/src/GeoJSON.Text/GeoJSON.Text.csproj
+++ b/src/GeoJSON.Text/GeoJSON.Text.csproj
@@ -15,6 +15,7 @@
 		<PackageTags>geojson;geo;json;geolocation</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageReleaseNotes></PackageReleaseNotes>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -31,6 +32,10 @@
 	</PropertyGroup>	
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 		<PackageReference Include="System.Text.Json" Version="6.0.1" />
 	</ItemGroup>

--- a/src/GeoJSON.Text/GeoJSON.Text.csproj
+++ b/src/GeoJSON.Text/GeoJSON.Text.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net5;net6</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<LangVersion>Latest</LangVersion>
 		<Description>.Net types for the GeoJSON RFC to be used with System.Text.Json</Description>
 		<Authors>Matt Hunt</Authors>

--- a/src/GeoJSON.Text/GeoJSONObject.cs
+++ b/src/GeoJSON.Text/GeoJSONObject.cs
@@ -86,7 +86,7 @@ namespace GeoJSON.Text
             {
                 return true;
             }
-            if (ReferenceEquals(null, right))
+            if (right is null)
             {
                 return false;
             }
@@ -101,8 +101,8 @@ namespace GeoJSON.Text
                 return false;
             }
 
-            var leftIsNull = ReferenceEquals(null, left.BoundingBoxes);
-            var rightIsNull = ReferenceEquals(null, right.BoundingBoxes);
+            var leftIsNull = left.BoundingBoxes is null;
+            var rightIsNull = right.BoundingBoxes is null;
             var bothAreMissing = leftIsNull && rightIsNull;
 
             if (bothAreMissing || leftIsNull != rightIsNull)
@@ -122,7 +122,7 @@ namespace GeoJSON.Text
             {
                 return true;
             }
-            if (ReferenceEquals(null, right))
+            if (right is null)
             {
                 return false;
             }

--- a/src/GeoJSON.Text/GeoJSONObject.cs
+++ b/src/GeoJSON.Text/GeoJSONObject.cs
@@ -15,7 +15,7 @@ namespace GeoJSON.Text
     /// </summary>
     public abstract class GeoJSONObject : IGeoJSONObject, IEqualityComparer<GeoJSONObject>, IEquatable<GeoJSONObject>
     {
-        internal static readonly DoubleTenDecimalPlaceComparer DoubleComparer = new DoubleTenDecimalPlaceComparer();
+        internal static readonly DoubleTenDecimalPlaceComparer DoubleComparer = new();
 
         /// <summary>
         ///     Gets or sets the (optional)

--- a/src/GeoJSON.Text/Geometry/GeometryCollection.cs
+++ b/src/GeoJSON.Text/Geometry/GeometryCollection.cs
@@ -20,7 +20,7 @@ namespace GeoJSON.Text.Geometry
         /// <summary>
         /// Initializes a new instance of the <see cref="GeometryCollection" /> class.
         /// </summary>
-        public GeometryCollection() : this(new Array.Empty[0])
+        public GeometryCollection() : this(Array.Empty<IGeometryObject>())
         {
         }
 
@@ -85,7 +85,7 @@ namespace GeoJSON.Text.Geometry
             {
                 return true;
             }
-            if (ReferenceEquals(null, right))
+            if (right is null)
             {
                 return false;
             }

--- a/src/GeoJSON.Text/Geometry/GeometryCollection.cs
+++ b/src/GeoJSON.Text/Geometry/GeometryCollection.cs
@@ -20,7 +20,7 @@ namespace GeoJSON.Text.Geometry
         /// <summary>
         /// Initializes a new instance of the <see cref="GeometryCollection" /> class.
         /// </summary>
-        public GeometryCollection() : this(new IGeometryObject[0])
+        public GeometryCollection() : this(new Array.Empty[0])
         {
         }
 

--- a/src/GeoJSON.Text/Geometry/LineString.cs
+++ b/src/GeoJSON.Text/Geometry/LineString.cs
@@ -29,7 +29,7 @@ namespace GeoJSON.Text.Geometry
         //[JsonConstructor]
         public LineString(IEnumerable<IEnumerable<double>> coordinates)
         : this(coordinates?.Select(latLongAlt => (IPosition)latLongAlt.ToPosition())
-               ?? throw new ArgumentException(nameof(coordinates)))
+               ?? throw new ArgumentNullException(nameof(coordinates)))
         {
         }
 
@@ -131,7 +131,7 @@ namespace GeoJSON.Text.Geometry
             {
                 return true;
             }
-            if (ReferenceEquals(null, right))
+            if (right is null)
             {
                 return false;
             }

--- a/src/GeoJSON.Text/Geometry/MultiLineString.cs
+++ b/src/GeoJSON.Text/Geometry/MultiLineString.cs
@@ -30,7 +30,7 @@ namespace GeoJSON.Text.Geometry
         public MultiLineString(IEnumerable<LineString> coordinates)
         {
             Coordinates =new ReadOnlyCollection<LineString>(
-                coordinates?.ToArray() ?? new LineString[0]);
+                coordinates?.ToArray() ?? Array.Empty<LineString>());
         }
 
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/MultiLineString.cs
+++ b/src/GeoJSON.Text/Geometry/MultiLineString.cs
@@ -95,7 +95,7 @@ namespace GeoJSON.Text.Geometry
             {
                 return true;
             }
-            if (ReferenceEquals(null, right))
+            if (right is null)
             {
                 return false;
             }

--- a/src/GeoJSON.Text/Geometry/MultiPoint.cs
+++ b/src/GeoJSON.Text/Geometry/MultiPoint.cs
@@ -89,7 +89,7 @@ namespace GeoJSON.Text.Geometry
             {
                 return true;
             }
-            if (ReferenceEquals(null, right))
+            if (right is null)
             {
                 return false;
             }

--- a/src/GeoJSON.Text/Geometry/MultiPoint.cs
+++ b/src/GeoJSON.Text/Geometry/MultiPoint.cs
@@ -28,7 +28,7 @@ namespace GeoJSON.Text.Geometry
         /// <param name="coordinates">The coordinates.</param>
         public MultiPoint(IEnumerable<Point> coordinates)
         {
-            Coordinates = new ReadOnlyCollection<Point>(coordinates?.ToArray() ?? new Point[0]);
+            Coordinates = new ReadOnlyCollection<Point>(coordinates?.ToArray() ?? Array.Empty<Point>());
         }
 
         //[JsonConstructor]

--- a/src/GeoJSON.Text/Geometry/Position.cs
+++ b/src/GeoJSON.Text/Geometry/Position.cs
@@ -135,7 +135,7 @@ namespace GeoJSON.Text.Geometry
             {
                 return true;
             }
-            if (ReferenceEquals(null, right) || ReferenceEquals(null, left))
+            if (right is null || left is null)
             {
                 return false;
             }

--- a/src/GeoJSON.Text/Geometry/Position.cs
+++ b/src/GeoJSON.Text/Geometry/Position.cs
@@ -12,7 +12,7 @@ namespace GeoJSON.Text.Geometry
     /// </summary>
     public class Position : IPosition, IEqualityComparer<Position>, IEquatable<Position>
     {
-        private static readonly DoubleTenDecimalPlaceComparer DoubleComparer = new DoubleTenDecimalPlaceComparer();
+        private static readonly DoubleTenDecimalPlaceComparer DoubleComparer = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Position" /> class.


### PR DESCRIPTION
I have changed GeoJSON.Text project, so that it's built using only .NET Standard 2.0, since it seems to have full System.Text.Json support and therefore makes direct .NET version targeting redundant.

Changed the windows runner version to specific version instead of latest, to ensure stability.

Also changed the release and benchmark actions to run from windows, since we have to run _build and tests_ on windows to use NET 4.6.2, and it therefore makes sense to run the actions on windows as well.

Also added the static code analyzer nuget package, and updated the code in regards to the generated messages. 
Though only in regards to the GeoJSON.Text project.

_PS_
Since I did rewrite the entire GeoJSON.NET package to support System.Text.Json, It would be very nice to have a little mention on this package.