### PR TITLE
Updated the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
    # Official NuGet Feed settings
   NUGET_FEED: https://api.nuget.org/v3/index.json
   NUGET_KEY: ${{ secrets.NUGET_KEY }}
+  NUGET_VERSIONING_REGEX: "[0-9]+\\.[0-9]+\\.[0-9]+-[a-zA-Z]+"  
 
 jobs:
   deploy:
@@ -37,9 +38,14 @@ jobs:
         run: dotnet build src/${{ env.PROJECT_NAME }}.sln -c Release --no-restore
       - name: Create Release NuGet package
         run: |
-          arrTag=(${GITHUB_REF//\// })
-          VERSION="${arrTag[2]}"
-          VERSION="${VERSION//v}"
-          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.csproj
+          $VERSION=${env:GITHUB_REF_NAME}
+          if($VERSION[0] -eq "v"){
+            $VERSION=$VERSION.substring(1)
+          }
+
+          if(!($VERSION -match ${env:NUGET_VERSIONING_REGEX})) {
+            throw "Release tag did not contain a valid NUGET version. TAG was : ${env:GITHUB_REF_NAME}"
+          }
+          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}.csproj
       - name: Push to Nuget
         run: dotnet nuget push nuget/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_KEY}} --skip-duplicate


### PR DESCRIPTION
- Updated the release action to pull version from release tag.
- Will throw error if release tag in not in the semantic version format allowed by nuget.
- Removes the prefix V if it exists in the tag.
- Also accepts preview versions.