### PR TITLE
Bugfix/no support of wildcard directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,4 @@ jobs:
           }
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}.csproj
       - name: Push to Nuget
-        run: |
-          gci ./nupkg/*.nupkg |
-            sort LastWriteTime -Descending |
-            select -First 1 |
-            % { dotnet nuget push $_.FullName --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_KEY}} --skip-duplicate }
+        run: dotnet nuget push ./nupkg/${{ env.PROJECT_NAME }}.${{ $VERSION }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_KEY}} --skip-duplicate }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   deploy:
     name: 'Deploy to Nuget'
     if: github.event_name == 'release'
-    runs-on: ubuntu-20.04
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v2
@@ -48,4 +48,8 @@ jobs:
           }
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}.csproj
       - name: Push to Nuget
-        run: dotnet nuget push nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_KEY}} --skip-duplicate
+        run: |
+          gci ./nupkg/*.nupkg |
+            sort LastWriteTime -Descending |
+            select -First 1 |
+            % { dotnet nuget push $_.FullName --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_KEY}} --skip-duplicate }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     name: 'Deploy to Nuget'
     if: github.event_name == 'release'
-    runs-on: windows-2019
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The dotnet nuget push command does not allow wildcards.

I updated the release action with some powershell code, that will function the same way as I expect the wildcard was meant to function.
It uses Get-ChildItem to find the nuget package, and pushes the top 1 result.

Tested on my own fork, and it seems like it finds the correct package, but have not tested the nuget push itself.