### PR TITLE
Fix for PositionConverter.Read SerializerSerializer - Issue #18

### DIFF
--- a/src/GeoJSON.Text/Converters/PositionConverter.cs
+++ b/src/GeoJSON.Text/Converters/PositionConverter.cs
@@ -44,7 +44,7 @@ namespace GeoJSON.Text.Converters
 
             try
             {
-                coordinates = JsonSerializer.Deserialize<double[]>(ref reader);
+                coordinates = JsonSerializer.Deserialize<double[]>(ref reader, options);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Passing the SerializationOptions along in the internal call to JsonSerializer in PositionConverter.Read(). See issue for details and repro with floating point string literals.