### PR TITLE
#24 Place conditions on STJ so only for net standard

### DIFF
--- a/src/GeoJSON.Text/GeoJSON.Text.csproj
+++ b/src/GeoJSON.Text/GeoJSON.Text.csproj
@@ -26,7 +26,7 @@
 
 	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-	</PropertyGroup>	
+	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
@@ -34,6 +34,9 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'== 'netStandard2.0'">
 		<PackageReference Include="System.Text.Json" Version="6.0.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
Makes STJ only included for Net standard 2.0 due to other TFM's natively providing STJ

Closes #24 