### PR TITLE
Update dependencies and target frameworks and fix build warnings

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,29 +25,27 @@ jobs:
       VSTEST_CONNECTION_TIMEOUT: 900
          
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
-            7.0.x
+            8.0.x
       - name: Install dependencies
         run: dotnet restore src/${{ env.PROJECT_NAME }}.sln
       - name: Build solution
         run: dotnet build src/${{ env.PROJECT_NAME }}.sln -c Release --no-restore
       - name: Test
         run: dotnet test src/${{ env.PROJECT_NAME }}.sln -c Release --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=../coverage/
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v4
         if: github.ref == 'refs/heads/main'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: src/coverage
           flags: unittests
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nupkg
           path: src/${{ env.PROJECT_NAME }}/bin/Release/*.nupkg

--- a/.github/workflows/continous-benchmark.yml
+++ b/.github/workflows/continous-benchmark.yml
@@ -13,21 +13,18 @@ jobs:
         working-directory: ./src
     
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
-            6.0.x
-            7.0.x
+            8.0.x
       # Run benchmark with `go test -bench` and stores the output to a file
       - name: Run benchmark
-        run:  dotnet run --project ./GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj --framework net6 --runtimes net60 -c Release -- --job medium -f *SerializeAndDeserialize*
+        run:  dotnet run --project ./GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj -c Release -- --job medium -f *SerializeAndDeserialize*
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark

--- a/src/GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj
+++ b/src/GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>

--- a/src/GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj
+++ b/src/GeoJSON.Text.Test.Benchmark/GeoJSON.Text.Test.Benchmark.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+	<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <SignAssembly>False</SignAssembly>
-	<LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="GeoJSON.Net" Version="1.2.19" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="GeoJSON.Net" Version="1.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GeoJSON.Text.Test.Benchmark/TestConfig.cs
+++ b/src/GeoJSON.Text.Test.Benchmark/TestConfig.cs
@@ -33,7 +33,7 @@ namespace GeoJSON.Text.Test.Benchmark
 
         private class FastestToSlowestOrderer : IOrderer
         {
-            public IEnumerable<BenchmarkCase> GetExecutionOrder(ImmutableArray<BenchmarkCase> benchmarksCase) =>
+            public IEnumerable<BenchmarkCase> GetExecutionOrder(ImmutableArray<BenchmarkCase> benchmarksCase, IEnumerable<BenchmarkLogicalGroupRule>? order = null) =>
                 from benchmark in benchmarksCase
                 orderby benchmark.Parameters["X"] descending,
                     benchmark.Descriptor.WorkloadMethodDisplayInfo
@@ -44,13 +44,13 @@ namespace GeoJSON.Text.Test.Benchmark
             public string GetLogicalGroupKey(ImmutableArray<BenchmarkCase> allBenchmarksCases, BenchmarkCase benchmarkCase) =>
                 benchmarkCase.Job.DisplayInfo + "_" + benchmarkCase.Parameters.DisplayInfo;
 
-            public IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups) =>
+            public IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups, IEnumerable<BenchmarkLogicalGroupRule>? order = null) =>
                 logicalGroups.OrderBy(it => it.Key);
 
             public IEnumerable<BenchmarkCase> GetSummaryOrder(ImmutableArray<BenchmarkCase> benchmarksCases, Summary summary)
             {
                 var benchmarkResult = from benchmark in benchmarksCases
-                                      orderby summary[benchmark].ResultStatistics.Mean
+                                      orderby summary[benchmark]?.ResultStatistics?.Mean ?? 0
                                       select benchmark;
 
                 return benchmarkResult;

--- a/src/GeoJSON.Text.Test.Unit/GeoJSON.Text.Test.Unit.csproj
+++ b/src/GeoJSON.Text.Test.Unit/GeoJSON.Text.Test.Unit.csproj
@@ -4,9 +4,8 @@
     <ProjectGuid>{6C93B314-9208-4684-B873-172F7EC81689}</ProjectGuid>
     <RootNamespace>GeoJSON.Text.Tests</RootNamespace>
     <AssemblyName>GeoJSON.Text.Tests</AssemblyName>
-    <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Feature\FeatureCollectionTests_Can_Deserialize.json" />
@@ -61,18 +60,18 @@
     <EmbeddedResource Include="Geometry\PolygonTests_Can_Serialize.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GeoJSON.Text\GeoJSON.Text.csproj" />

--- a/src/GeoJSON.Text/GeoJSON.Text.csproj
+++ b/src/GeoJSON.Text/GeoJSON.Text.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0;netstandard2.0</TargetFrameworks>
 		<LangVersion>10</LangVersion>
 		<Description>.Net types for the GeoJSON RFC to be used with System.Text.Json</Description>
 		<Authors>Matt Hunt</Authors>
@@ -29,15 +29,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'== 'netStandard2.0'">
-		<PackageReference Include="System.Text.Json" Version="6.0.1" />
+	<ItemGroup Condition="'$(TargetFramework)'== 'netstandard2.0'">
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Starting with .NET 9, NuGet Audit will transitively scan for CVEs, so consuming applications will get a warning about System.Text.Json:

>  warning NU1903: Package 'System.Text.Json' 6.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4

#24 already optimized this to only affect .NET Framework (but it's still not released).

This updates all dependencies (except Nunit 4 which has a lot of breaking changes) and cleans up some build warnings:

- removed netstandard2.0 from test projects. This doesn't make sense because you can't run tests against netstandard2.0 (LangVersion also isn't needed anymore then)
- removed EOL net7.0 target and added net8.0
- removed `Microsoft.CodeAnalysis.NetAnalyzers`because it's part of the SDK since .NET 5