### PR TITLE
Use generic JsonStringEnumConverter

### DIFF
--- a/src/GeoJSON.Text/Converters/CrsConverter.cs
+++ b/src/GeoJSON.Text/Converters/CrsConverter.cs
@@ -10,7 +10,7 @@ namespace GeoJSON.Text.Converters
     /// <summary>
     /// Converts <see cref="ICRSObject"/> types to and from JSON.
     /// </summary>
-    public class CrsConverter : JsonConverter<object>
+    public class CrsConverter : JsonConverter<ICRSObject>
     {
         public override bool HandleNull => true;
 
@@ -41,7 +41,7 @@ namespace GeoJSON.Text.Converters
         ///     or
         /// CRS must have a "type" property
         /// </exception>
-        public override object Read(
+        public override ICRSObject Read(
             ref Utf8JsonReader reader,
             Type type,
             JsonSerializerOptions options)
@@ -106,7 +106,8 @@ namespace GeoJSON.Text.Converters
                 }
             }
 
-            return new NotSupportedException(string.Format("Type {0} unexpected.", crsType));
+            //return new NotSupportedException(string.Format("Type {0} unexpected.", crsType));
+            return null;
         }
 
         /// <summary>
@@ -118,7 +119,7 @@ namespace GeoJSON.Text.Converters
         /// <exception cref="System.ArgumentOutOfRangeException"></exception>
         public override void Write(
             Utf8JsonWriter writer,
-            object crsValue,
+            ICRSObject crsValue,
             JsonSerializerOptions options)
         {
             var value = (ICRSObject)crsValue;

--- a/src/GeoJSON.Text/Feature/Feature.cs
+++ b/src/GeoJSON.Text/Feature/Feature.cs
@@ -49,7 +49,6 @@ namespace GeoJSON.Text.Feature
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.Feature;
 
         [JsonPropertyName( "id")]

--- a/src/GeoJSON.Text/Feature/FeatureCollection.cs
+++ b/src/GeoJSON.Text/Feature/FeatureCollection.cs
@@ -37,7 +37,6 @@ public class FeatureCollection : GeoJSONObject, IEqualityComparer<FeatureCollect
 
     [JsonPropertyName("type")]
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public override GeoJSONObjectType Type => GeoJSONObjectType.FeatureCollection;
 
     /// <summary>
@@ -156,7 +155,6 @@ public class FeatureCollection<TProps> : FeatureCollection, IEqualityComparer<Fe
 
     [JsonPropertyName("type")]
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public override GeoJSONObjectType Type => GeoJSONObjectType.FeatureCollection;
 
     /// <summary>

--- a/src/GeoJSON.Text/GeoJSONObject.cs
+++ b/src/GeoJSON.Text/GeoJSONObject.cs
@@ -55,7 +55,6 @@ namespace GeoJSON.Text
         /// </summary>
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public abstract GeoJSONObjectType Type { get; }
 
 

--- a/src/GeoJSON.Text/GeoJSONObjectType.cs
+++ b/src/GeoJSON.Text/GeoJSONObjectType.cs
@@ -1,12 +1,18 @@
 ﻿// Copyright © Joerg Battermann 2014, Matt Hunt 2017
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace GeoJSON.Text
 {
     /// <summary>
     /// Defines the GeoJSON Objects types.
     /// </summary>
+#if NET8_0_OR_GREATER
+    [JsonConverter(typeof(JsonStringEnumConverter<GeoJSONObjectType>))]
+#else
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+#endif
     public enum GeoJSONObjectType
     {
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/GeometryCollection.cs
+++ b/src/GeoJSON.Text/Geometry/GeometryCollection.cs
@@ -36,7 +36,6 @@ namespace GeoJSON.Text.Geometry
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.GeometryCollection;
 
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/IGeometryObject.cs
+++ b/src/GeoJSON.Text/Geometry/IGeometryObject.cs
@@ -23,7 +23,6 @@ namespace GeoJSON.Text.Geometry
         /// The type of the object.
         /// </value>
         [JsonPropertyName("type")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         GeoJSONObjectType Type { get; }
     }
 }

--- a/src/GeoJSON.Text/Geometry/LineString.cs
+++ b/src/GeoJSON.Text/Geometry/LineString.cs
@@ -52,7 +52,6 @@ namespace GeoJSON.Text.Geometry
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.LineString;
 
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/MultiLineString.cs
+++ b/src/GeoJSON.Text/Geometry/MultiLineString.cs
@@ -46,7 +46,6 @@ namespace GeoJSON.Text.Geometry
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.MultiLineString;
 
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/MultiPoint.cs
+++ b/src/GeoJSON.Text/Geometry/MultiPoint.cs
@@ -40,7 +40,6 @@ namespace GeoJSON.Text.Geometry
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.MultiPoint;
 
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/MultiPolygon.cs
+++ b/src/GeoJSON.Text/Geometry/MultiPolygon.cs
@@ -42,7 +42,6 @@ namespace GeoJSON.Text.Geometry
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.MultiPolygon;
 
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/Point.cs
+++ b/src/GeoJSON.Text/Geometry/Point.cs
@@ -31,7 +31,6 @@ namespace GeoJSON.Text.Geometry
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.Point;
 
         /// <summary>

--- a/src/GeoJSON.Text/Geometry/Polygon.cs
+++ b/src/GeoJSON.Text/Geometry/Polygon.cs
@@ -57,7 +57,6 @@ namespace GeoJSON.Text.Geometry
 
         [JsonPropertyName("type")]
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
         public override GeoJSONObjectType Type => GeoJSONObjectType.Polygon;
 
         /// <summary>


### PR DESCRIPTION
Using the generic [JsonStringEnumConverter\<TEnum\>](https://learn.microsoft.com/dotnet/api/system.text.json.serialization.jsonstringenumconverter-1) (available since net8.0) instead of non-generic [JsonStringEnumConverter](https://learn.microsoft.com/dotnet/api/system.text.json.serialization.jsonstringenumconverter)

So [source generation](https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation) for [Trimming](https://learn.microsoft.com/dotnet/core/deploying/trimming/incompatibilities) and [Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot) is possible.

This closes #30